### PR TITLE
`getComponentDefaultProps` should skip undefined defaults

### DIFF
--- a/__tests__/index.spec.js
+++ b/__tests__/index.spec.js
@@ -387,5 +387,24 @@ describe('withPropDocs', () => {
         foo: 'bar',
       })
     })
+
+    it('skips undefined default props', () => {
+      const Cmp = ({ children }) => children
+
+      withPropDocs({
+        name: 'Cmp',
+        props: {
+          foo: {
+            type: string,
+            default: 'bar',
+          },
+          baz: {
+            type: string,
+          },
+        },
+      })(Cmp)
+
+      expect(Cmp.defaultProps).toEqual({ foo: 'bar' })
+    })
   })
 })

--- a/src/index.js
+++ b/src/index.js
@@ -13,12 +13,13 @@ const getComponentPropTypes = props =>
 
 const getComponentDefaultProps = props =>
   Object.keys(props).reduce((acc, key) => {
-    return Object.assign({}, acc, {
-      [key]:
-        props[key].type.name === 'shape'
-          ? getComponentDefaultProps(props[key].props)
-          : props[key].default,
-    })
+    const defaultProp =
+      props[key].type.name === 'shape'
+        ? getComponentDefaultProps(props[key].props)
+        : props[key].default
+    return defaultProp === undefined
+      ? acc
+      : Object.assign({}, acc, { [key]: defaultProp })
   }, {})
 
 const withPropDocs = ({


### PR DESCRIPTION
`getComponentDefaultProps` currently returns a value for every property regardless of whether or not a `default` config has been provided.

AFAIK it shacouldn't be impacting the actual component logic but it can lead to unnecessary JSX bloat

```js
const Comp = withPropDocs({
  name: 'Cmp',
  props: {
    foo: { type: string }, // omitting default results in explicit undefined
  },
  props: {
    bar: { type: string },
    default: 'bar'
  },
})(Component)
```
```js
<Comp />
// expands to:
<Component bar={"bar"} foo={undefined} />
```